### PR TITLE
fix: make task IDs CSS-safe to prevent querySelector crash

### DIFF
--- a/src/task-mapper.ts
+++ b/src/task-mapper.ts
@@ -36,11 +36,14 @@ function extractRawValue(val: Value | null): string | null {
 }
 
 /**
- * Make a stable task ID from a file path.
- * Frappe Gantt replaces spaces with underscores internally, so we do the same.
+ * Make a stable, CSS-safe task ID from a file path.
+ * Frappe Gantt uses the ID as a CSS class (e.g. `.highlight-{id}`),
+ * so we must strip characters invalid in selectors: / . etc.
  */
 function makeTaskId(filePath: string): string {
-	return filePath.replace(/ /g, '_');
+	return filePath
+		.replace(/\.[^.]+$/, '')   // strip file extension
+		.replace(/[^a-zA-Z0-9_-]/g, '_');  // replace anything not CSS-safe
 }
 
 /** Prefix used to identify group header phantom tasks. */


### PR DESCRIPTION
## Summary

- Frappe Gantt uses task IDs as CSS classes internally (e.g. `.highlight-{id}`)
- File paths containing `/` and `.` characters produce invalid CSS selectors, causing `DOMException: Failed to execute 'querySelector'`
- Fix: strip file extension and replace non-alphanumeric characters with underscores in `makeTaskId()`

## Reproduction

Any vault with notes in subfolders (e.g. `10 Projects/ideas/My-Task.md`) triggers the error on hover/click.

## Test plan

- [ ] Open a Base with notes in nested folders
- [ ] Verify no `querySelector` errors in console
- [ ] Verify click-to-open and hover popup still work